### PR TITLE
Expand ~ to $HOME from bookmarks

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -17,7 +17,7 @@ fzfcmd() {
 function jump() {
     local jumpline=$(cat ${BOOKMARKS_FILE} | $(fzfcmd) --bind=ctrl-y:accept --tac)
     if [[ -n ${jumpline} ]]; then
-        local jumpdir=$(echo $jumpline | awk '{print $3}')
+        local jumpdir=$(echo $jumpline | awk '{print $3}' | sed "s#~#$HOME#")
         sed --follow-symlinks -i "\#${jumpline}#d" $BOOKMARKS_FILE
         cd ${jumpdir} && echo ${jumpline} >> $BOOKMARKS_FILE
     fi

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -17,7 +17,7 @@ fzfcmd() {
 function jump() {
     jumpline=$(cat ${BOOKMARKS_FILE} | $(fzfcmd) --bind=ctrl-y:accept --tac)
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo $jumpline | awk '{print $3}')
+        jumpdir=$(echo $jumpline | awk '{print $3}' | sed "s#~#$HOME#")
         sed -i --follow-symlinks "\#${jumpline}#d" $BOOKMARKS_FILE
         cd ${jumpdir} && echo ${jumpline} >> $BOOKMARKS_FILE
     fi


### PR DESCRIPTION
This allows the use of ~ in the `.bookmarks` file. This will never be added by the `mark` command, but I find it to be useful when I want to manually write a file to share between machines that may not have the same home directory.