### PR TITLE
"sed --follow-link -i" is not fully osx compatible

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -18,7 +18,7 @@ function jump() {
     local jumpline=$(cat ${BOOKMARKS_FILE} | $(fzfcmd) --bind=ctrl-y:accept --tac)
     if [[ -n ${jumpline} ]]; then
         local jumpdir=$(echo $jumpline | awk '{print $3}' | sed "s#~#$HOME#")
-        sed --follow-symlinks -i "\#${jumpline}#d" $BOOKMARKS_FILE
+        perl -p -i -e "s#${jumpline}\n##g" $BOOKMARKS_FILE
         cd ${jumpdir} && echo ${jumpline} >> $BOOKMARKS_FILE
     fi
 }
@@ -27,7 +27,7 @@ function dmark()  {
     local marks_to_delete=$(cat $BOOKMARKS_FILE | $(fzfcmd) -m --bind=ctrl-y:accept,ctrl-t:toggle-up --tac)
 
     while read -r line; do
-        sed -i --follow-symlinks "\#${line}#d" $BOOKMARKS_FILE
+        perl -p -i -e "s#${line}\n##g" $BOOKMARKS_FILE
     done <<< "$marks_to_delete"
 
     echo "** The following marks were deleted **"


### PR DESCRIPTION
Hi,

`sed -i` without extension is not supported in OSX. The same is for `sed --follow-symlinks`.
I think `perl` is more platform compatible.

Unfortunately Perl has no follow-symlinks, but I think it is not necessary because `$BOOKMARKS_FILE` isn't a symbolic link. Can you clarify why you added it? 


Best,
Thomas