### PR TITLE
mark function: ensure whitespace before colon

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -7,7 +7,7 @@ if [[ ! -f $BOOKMARKS_FILE ]]; then
 fi
 
 function mark() {
-    echo $@ : $(pwd) >> $BOOKMARKS_FILE
+    echo "$@ : $(pwd)" >> $BOOKMARKS_FILE
 }
 
 fzfcmd() {


### PR DESCRIPTION
Without this change, when you run `mark` without any argument, it will write `: /path/to/dir` into bookmarks file. And such line cannot be properly parsed by sed used in jump command.
Alternate solution is to fix sed regexp.