### PR TITLE
Prezto module init symlink

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,0 +1,1 @@
+fzf-marks.plugin.zsh


### PR DESCRIPTION
This symlink enables cloning fzf-mark as a [prezto module](https://github.com/sorin-ionescu/prezto).