### PR TITLE
Prevent adding duplicate bookmarks

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -25,9 +25,13 @@ fi
 function mark() {
     local mark_to_add
     mark_to_add=$(echo "$* : $(pwd)")
-    echo "${mark_to_add}" >> "${BOOKMARKS_FILE}"
 
-    echo "** The following mark has been added **"
+    if grep -qxFe "${mark_to_add}" "${BOOKMARKS_FILE}"; then
+        echo "** The following mark already exists **"
+    else
+        echo "${mark_to_add}" >> "${BOOKMARKS_FILE}"
+        echo "** The following mark has been added **"
+    fi
     echo "${mark_to_add}"
 }
 

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -25,9 +25,13 @@ fi
 function mark() {
     local mark_to_add
     mark_to_add=$(echo "$* : $(pwd)")
-    echo "${mark_to_add}" >> "${BOOKMARKS_FILE}"
 
-    echo "** The following mark has been added **"
+    if grep -qxFe "${mark_to_add}" "${BOOKMARKS_FILE}"; then
+        echo "** The following mark already exists **"
+    else
+        echo "${mark_to_add}" >> "${BOOKMARKS_FILE}"
+        echo "** The following mark has been added **"
+    fi
     echo "${mark_to_add}"
 }
 


### PR DESCRIPTION
The grep flags are [explained here](https://unix.stackexchange.com/a/5757/280976).

This checks the entire entry, so a user is still able to create bookmarks to the same directory with different names.