### PR TITLE
Read relative symlinks

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -62,7 +62,7 @@ function mark {
 function _handle_symlinks {
     local fname
     if [ -L "${FZF_MARKS_FILE}" ]; then
-        fname=$(readlink "${FZF_MARKS_FILE}")
+        fname=$(readlink -f "${FZF_MARKS_FILE}")
     else
         fname=${FZF_MARKS_FILE}
     fi


### PR DESCRIPTION
Adding the `-f` flag allows the use of relative symlinks for `$FZF_MARKS_FILE`

```sh
$ readlink .fzf-marks 
.dotfiles/.fzf-marks
```

```sh
$ readlink -f .fzf-marks 
/home/leon/.dotfiles/.fzf-marks
```