### PR TITLE
Make jumpdir handle marks without aliases

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -112,7 +112,7 @@ function jump {
         jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query="$*" --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo "${jumpline}" | sed -n 's/.* : \(.*\)$/\1/p' | sed "s#~#${HOME}#")
+        jumpdir=$(echo "${jumpline}" | sed -n 's/.* \?: \(.*\)$/\1/p' | sed "s#~#${HOME}#")
         bookmarks=$(_handle_symlinks)
         perl -n -i -e "print unless /^${jumpline//\//\\/}\$/" "${bookmarks}"
         cd "${jumpdir}" && echo "${jumpline}" >> "${FZF_MARKS_FILE}"


### PR DESCRIPTION
```sh
$ cat ~/.fzf-marks 
: /home/leon/Workspaces/go/src/bitbucket.org/tim_online/kahn
: /home/leon/Workspaces/go/src/github.com/tim-online
: /home/leon/Workspaces/go/src/github.com/leonb/brewfun
: /home/leon/Workspaces/go/src/bitbucket.org/tim_online
```

This patch allows me to use `jump` without using aliases in the marks file