### PR TITLE
set current foldername as default mark

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -46,7 +46,7 @@ fi
 
 function mark {
     local mark_to_add
-    mark_to_add="$* : $(pwd)"
+    mark_to_add="${*:-$(basename "$(pwd)")} : $(pwd)"
 
     if grep -qxFe "${mark_to_add}" "${FZF_MARKS_FILE}"; then
         echo "** The following mark already exists **"

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -44,7 +44,7 @@ fi
 
 function mark {
     local mark_to_add
-    mark_to_add="$* : $(pwd)"
+    mark_to_add="${*:-$(basename "$(pwd)")} : $(pwd)"
 
     if grep -qxFe "${mark_to_add}" "${FZF_MARKS_FILE}"; then
         echo "** The following mark already exists **"


### PR DESCRIPTION
I usually set the name of my current working directory as key for fzf-mark. To make this process easier, typing only `mark` does this now automatically if no explicit name is given. 

Is this useful for you?