### PR TITLE
Replaces only the begining `~` to $HOME.

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -114,7 +114,7 @@ function jump {
         jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query="$*" --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#~#${HOME}#")
+        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
         bookmarks=$(_handle_symlinks)
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then

--- a/fzf-marks.plugin.fish
+++ b/fzf-marks.plugin.fish
@@ -122,7 +122,7 @@ function jump
                 --tac)
     end
     if test -n $jumpline
-        set -l jumpdir (echo "$jumpline" | sed 's/.*: \(.*\)$/\1/' | sed "s#~#$HOME#")
+        set -l jumpdir (echo "$jumpline" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#$HOME#")
         set -l bookmarks (_handle_symlinks)
         cd $jumpdir
         commandline -f repaint

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -124,7 +124,7 @@ function jump {
         jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query="$*" --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#~#${HOME}#")
+        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
         bookmarks=$(_handle_symlinks)
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then


### PR DESCRIPTION
fzf-marks is broken if any path contains a `~` in the middle but not at the begining of it. Therefore only the initial `~` should be replaced.