### PR TITLE
Auto-accept on exact match

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -120,10 +120,15 @@ function jump {
     if [[ $1 == "-->-->-->" ]]; then
         jumpline=$2
     else
-        jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
-            --ansi \
-            --bind=ctrl-y:accept --header='"ctrl-y:jump"' \
-            --query='"$*"' --select-1 --tac)
+        # accept if provided string matches a single bookmark exactly
+        (($#)) && jumpline=$(grep "^$* : .*\$" "$FZF_MARKS_FILE")
+        [[ ${jumpline} =~ $'\n' ]] && jumpline=
+        # if not, prompt using fzf
+        [[ $jumpline ]] || \
+          jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
+              --ansi \
+              --bind=ctrl-y:accept --header='"ctrl-y:jump"' \
+              --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
         jumpdir=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< $jumpline)

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -99,6 +99,7 @@ function fzm {
         --header='"ctrl-y:jump, ctrl-t:toggle, $delete_key:delete, $paste_key:paste"' \
         --query='"$*"' \
         --select-1 \
+        --no-sort \
         --tac)
     if [[ -z "$lines" ]]; then
         return 1
@@ -128,7 +129,7 @@ function jump {
           jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
               --ansi \
               --bind=ctrl-y:accept --header='"ctrl-y:jump"' \
-              --query='"$*"' --select-1 --tac)
+              --query='"$*"' --select-1 --no-sort --tac)
     fi
     if [[ -n ${jumpline} ]]; then
         jumpdir=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< $jumpline)


### PR DESCRIPTION
e.g. if I have only one bookmark containing the string 'foo' exactly and I type 'jump foo', don't bother bringing up fzf and just cd to that directory. This differs from the current behavior in that if I have a bookmark that is an inexact match for 'foo' (like 'four') then fzf will not currently auto-accept the exact match.