### PR TITLE
added possibilty to paste a directory

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -36,7 +36,7 @@ if [[ -z "${FZF_MARKS_COMMAND}" ]] ; then
     MINIMUM_VERSION=16001
 
     if [[ $FZF_VERSION -gt $MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header='ctrl-y:jump, ctrl-t:toggle, ctrl-d:delete'"
+        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header='ctrl-y:jump, ctrl-t:toggle, ctrl-d:delete, ctrl-k:paste'"
     elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
         FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
     else
@@ -92,7 +92,7 @@ function _color_marks {
 function fzm {
     lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \
-        --expect="${FZF_MARKS_DELETE:-ctrl-d}" \
+        --expect="${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}" \
         --multi \
         --bind=ctrl-y:accept,ctrl-t:toggle \
         --query="\"$*\"" \
@@ -106,6 +106,8 @@ function fzm {
 
     if [[ $key == "${FZF_MARKS_DELETE:-ctrl-d}" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
+    elif [[ $key == "${FZF_MARKS_PASTE:-ctrl-k}" ]]; then
+        pmark "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"
     fi
@@ -127,6 +129,10 @@ function jump {
             echo "${jumpline}" >> "${FZF_MARKS_FILE}"
         fi
     fi
+}
+
+function pmark {
+    echo $(echo "${1}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
 }
 
 function dmark {

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -34,7 +34,7 @@ if [[ -z "${FZF_MARKS_COMMAND}" ]] ; then
     MINIMUM_VERSION=16001
 
     if [[ $FZF_VERSION -gt $MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header='ctrl-y:jump, ctrl-t:toggle, ctrl-d:delete'"
+        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header='ctrl-y:jump, ctrl-t:toggle, ctrl-d:delete, ctrl-k:paste'"
     elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
         FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
     else
@@ -96,7 +96,7 @@ function fzm {
     local lines key
     lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \
-        --expect="${FZF_MARKS_DELETE:-ctrl-d}" \
+        --expect="${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}" \
         --multi \
         --bind=ctrl-y:accept,ctrl-t:toggle \
         --query="\"$*\"" \
@@ -111,6 +111,8 @@ function fzm {
 
     if [[ $key == "${FZF_MARKS_DELETE:-ctrl-d}" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
+    elif [[ $key == "${FZF_MARKS_PASTE:-ctrl-k}" ]]; then
+        pmark "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"
     fi
@@ -133,6 +135,10 @@ function jump {
         fi
     fi
     zle && zle redraw-prompt
+}
+
+function pmark {
+    echo $(echo "${1}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
 }
 
 function dmark {
@@ -158,6 +164,7 @@ function dmark {
 }
 
 zle -N jump
+zle -N pmark
 zle -N dmark
 zle -N fzm
 


### PR DESCRIPTION
Hi, as sugested in issue #40 it would be great to add a way to paste the path to a directory to make it easy to do these kinds of actions
```
$ ls `fzm`
$ cp file1.txt `fzm`
 ```
 Then we can hit ctrl-k by default to paste the path and the command substitution will be replaced by the bookmark path when the comand gets executed.
 Similar to what you did with the delete key, the default pasting key can be modified with $FZF_MARKS_PASTE

I don't think its possible through this script to be able to hit Ctrl-g and directly paste the path as sugested in the issue..