### PR TITLE
Support key binding for Bash 3

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -36,7 +36,7 @@ if [[ -z "${FZF_MARKS_COMMAND}" ]] ; then
     MINIMUM_VERSION=16001
 
     if [[ $FZF_VERSION -gt $MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header='ctrl-y:jump, ctrl-t:toggle, ctrl-d:delete, ctrl-k:paste'"
+        FZF_MARKS_COMMAND="fzf --height 40% --reverse --header=\"\$_fzm_keymap_description\""
     elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
         FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
     else
@@ -90,9 +90,11 @@ function _color_marks {
 }
 
 function fzm {
-    lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
+    local delete_key=${FZF_MARKS_DELETE:-ctrl-d} paste_key=${FZF_MARKS_PASTE:-ctrl-k}
+    local _fzm_keymap_description="ctrl-y:jump, ctrl-t:toggle, $delete_key:delete, $paste_key:paste"
+    local lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \
-        --expect='"${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}"' \
+        --expect='"$delete_key,$paste_key"' \
         --multi \
         --bind=ctrl-y:accept,ctrl-t:toggle \
         --query='"$*"' \
@@ -102,11 +104,11 @@ function fzm {
         return 1
     fi
 
-    key=$(head -1 <<< "$lines")
+    local key=$(head -1 <<< "$lines")
 
-    if [[ $key == "${FZF_MARKS_DELETE:-ctrl-d}" ]]; then
+    if [[ $key == "$delete_key" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
-    elif [[ $key == "${FZF_MARKS_PASTE:-ctrl-k}" ]]; then
+    elif [[ $key == "$paste_key" ]]; then
         pmark "-->-->-->" "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"
@@ -118,6 +120,7 @@ function jump {
     if [[ $1 == "-->-->-->" ]]; then
         jumpline=$2
     else
+        local _fzm_keymap_description="ctrl-y:jump"
         jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
@@ -151,6 +154,7 @@ function dmark {
     if [[ $1 == "-->-->-->" ]]; then
         marks_to_delete=$2
     else
+        local _fzm_keymap_description="ctrl-y:delete, ctrl-t:toggle"
         marks_to_delete=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} -m --ansi --bind=ctrl-y:accept,ctrl-t:toggle --query='"$*"' --tac)
     fi
     bookmarks=$(_handle_symlinks)

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -299,8 +299,9 @@ function ble/widget/fzm {
 }
 
 function set-up-fzm-bindings {
-    if [[ $BLE_VERSION ]]; then
-        ble-bind -f 'C-g' 'fzm'
+    local jump_key=${FZF_MARKS_JUMP:-'\C-g'}
+    if ((_ble_version>=400)); then
+        ble-bind -f keyseq:"$jump_key" 'fzm'
     else
         # Intiialize special keys used for key bindings
         _fzm_key1='\200'
@@ -319,7 +320,7 @@ function set-up-fzm-bindings {
         fi
 
         bind -x "\"$_fzm_key1\": _fzm-widget"
-        bind "\"${FZF_MARKS_JUMP:-\C-g}\":\"$_fzm_key1$_fzm_key2\""
+        bind "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
     fi
 
     if [ "${FZF_MARKS_DMARK}" ]; then

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -107,7 +107,7 @@ function fzm {
     if [[ $key == "${FZF_MARKS_DELETE:-ctrl-d}" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
     elif [[ $key == "${FZF_MARKS_PASTE:-ctrl-k}" ]]; then
-        pmark "$(tail -1 <<< "$lines")"
+        pmark "-->-->-->" "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"
     fi
@@ -132,9 +132,18 @@ function jump {
 }
 
 function pmark {
-    local selected="$(echo "${1}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")"
-    local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
-    eval -- "$paste_command \"\$selected\""
+    local selected
+    if [[ $1 == "-->-->-->" ]]; then
+        selected=$2
+    else
+        local _fzm_keymap_description="ctrl-y:paste"
+        selected=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
+    fi
+    if [[ $selected ]]; then
+        selected=$(sed 's/.*: \(.*\)$/\1/;s#^~#${HOME}#' <<< $selected)
+        local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
+        eval -- "$paste_command \"\$selected\""
+    fi
 }
 
 function dmark {

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -108,7 +108,7 @@ function fzm {
 
     if [[ $key == "$delete_key" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
-    elif [[ $key == "$paste_key" ]]; then
+    elif [[ $key == "$paste_key" || ! -t 1 ]]; then
         pmark "-->-->-->" "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -90,7 +90,7 @@ function _color_marks {
 }
 
 function fzm {
-    local delete_key=${FZF_MARKS_DELETE:-ctrl-d} paste_key=${FZF_MARKS_PASTE:-ctrl-k}
+    local delete_key=${FZF_MARKS_DELETE:-ctrl-d} paste_key=${FZF_MARKS_PASTE:-ctrl-v}
     local _fzm_keymap_description="ctrl-y:jump, ctrl-t:toggle, $delete_key:delete, $paste_key:paste"
     local lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -171,18 +171,26 @@ function set-up-fzm-bindings {
     elif [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
         bind "\"\C-g\":\"fzm\C-m\""
     else
-        local mark1='\200' mark2='\201' mark3='\202'
-
-        # Change markers for UTF-8 encodings
+        # Intiialize special keys used for key bindings
+        _fzm_key1='\200'
+        _fzm_key2='\201'
+        _fzm_key3='\202'
         local locale=${LC_ALL:-${LC_CTYPE:-$LANG}}
         local rex_utf8='\.([uU][tT][fF]-?8)$'
         if [[ $locale =~ $rex_utf8 ]]; then
-          mark1='\302\200' mark2='\302\201' mark3='\302\202'
+            # Change keys for UTF-8 encodings:
+            # Two-byte sequence does not work for Bash 3 and 4.
+            # \xC0-\xC1 and \xF5-\xFF are unused bytes in UTF-8.
+            # Bash 4 unintendedly exits with \xFE-\xFF.
+            _fzm_key1='\xC0'
+            _fzm_key2='\xC1'
+            _fzm_key3='\xFD'
         fi
-        bind -x "\"$mark1\": _FZF_MARKS_LINE=\$READLINE_LINE _FZF_MARKS_POINT=\$READLINE_POINT"
-        bind -x "\"$mark2\": READLINE_LINE=\$_FZF_MARKS_LINE READLINE_POINT=\$_FZF_MARKS_POINT; unset -v _FZF_MARKS_POINT _FZF_MARKS_LINE"
-        bind -x "\"$mark3\": fzm"
-        bind "\"${FZF_MARKS_JUMP:-\C-g}\":\"$mark3$mark1\C-a\C-k\C-m$mark2\""
+
+        bind -x "\"$_fzm_key2\": _FZF_MARKS_LINE=\$READLINE_LINE _FZF_MARKS_POINT=\$READLINE_POINT"
+        bind -x "\"$_fzm_key3\": READLINE_LINE=\$_FZF_MARKS_LINE READLINE_POINT=\$_FZF_MARKS_POINT; unset -v _FZF_MARKS_POINT _FZF_MARKS_LINE"
+        bind -x "\"$_fzm_key1\": fzm"
+        bind "\"${FZF_MARKS_JUMP:-\C-g}\":\"$_fzm_key1$_fzm_key2\C-a\C-k\C-m$_fzm_key3\""
     fi
 
     if [ "${FZF_MARKS_DMARK}" ]; then

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -92,10 +92,10 @@ function _color_marks {
 function fzm {
     lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \
-        --expect="${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}" \
+        --expect='"${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}"' \
         --multi \
         --bind=ctrl-y:accept,ctrl-t:toggle \
-        --query="\"$*\"" \
+        --query='"$*"' \
         --select-1 \
         --tac)
     if [[ -z "$lines" ]]; then
@@ -118,7 +118,7 @@ function jump {
     if [[ $1 == "-->-->-->" ]]; then
         jumpline=$2
     else
-        jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query="$*" --select-1 --tac)
+        jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
         jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
@@ -142,7 +142,7 @@ function dmark {
     if [[ $1 == "-->-->-->" ]]; then
         marks_to_delete=$2
     else
-        marks_to_delete=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} -m --ansi --bind=ctrl-y:accept,ctrl-t:toggle --query="$*" --tac)
+        marks_to_delete=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} -m --ansi --bind=ctrl-y:accept,ctrl-t:toggle --query='"$*"' --tac)
     fi
     bookmarks=$(_handle_symlinks)
 

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -324,7 +324,7 @@ function set-up-fzm-bindings {
     fi
 
     if [ "${FZF_MARKS_DMARK}" ]; then
-        bind "\"${FZF_MARKS_DMARK}\":\"dmark\\n\""
+        bind -x "\"${FZF_MARKS_DMARK}\": dmark"
     fi
 }
 

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -99,7 +99,7 @@ function _fzm_paste_command {
 }
 
 function fzm {
-    local delete_key=${FZF_MARKS_DELETE:-ctrl-d} paste_key=${FZF_MARKS_PASTE:-ctrl-k}
+    local delete_key=${FZF_MARKS_DELETE:-ctrl-d} paste_key=${FZF_MARKS_PASTE:-ctrl-v}
     local _fzm_keymap_description="ctrl-y:jump, ctrl-t:toggle, ${delete_key}:delete, ${paste_key}:paste"
     local lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -118,7 +118,7 @@ function fzm {
 
     if [[ $key == "$delete_key" ]]; then
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
-    elif [[ $key == "$paste_key" ]]; then
+    elif [[ $key == "$paste_key" || ! -t 1 ]]; then
         zle && local FZF_MARKS_PASTE_COMMAND=_fzm_paste_command
         pmark "-->-->-->" "$(tail -1 <<< "$lines")"
     else

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -102,10 +102,10 @@ function fzm {
     local lines key
     lines=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
         --ansi \
-        --expect="${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}" \
+        --expect='"${FZF_MARKS_DELETE:-ctrl-d},${FZM_MARKS_PASTE:-ctrl-k}"' \
         --multi \
         --bind=ctrl-y:accept,ctrl-t:toggle \
-        --query="\"$*\"" \
+        --query='"$*"' \
         --select-1 \
         --tac)
     if [[ -z "$lines" ]]; then
@@ -130,7 +130,7 @@ function jump {
     if [[ $1 == "-->-->-->" ]]; then
         jumpline=$2
     else
-        jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query="$*" --select-1 --tac)
+        jumpline=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
         jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
@@ -155,7 +155,7 @@ function dmark {
     if [[ $1 == "-->-->-->" ]]; then
         marks_to_delete=$2
     else
-        marks_to_delete=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} -m --ansi --bind=ctrl-y:accept,ctrl-t:toggle --query="$*" --tac)
+        marks_to_delete=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} -m --ansi --bind=ctrl-y:accept,ctrl-t:toggle --query='"$*"' --tac)
     fi
     bookmarks=$(_handle_symlinks)
 

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -119,7 +119,7 @@ function fzm {
         dmark "-->-->-->" "$(sed 1d <<< "$lines")"
     elif [[ $key == "${FZF_MARKS_PASTE:-ctrl-k}" ]]; then
         zle && local FZF_MARKS_PASTE_COMMAND=_fzm_paste_command
-        pmark "$(tail -1 <<< "$lines")"
+        pmark "-->-->-->" "$(tail -1 <<< "$lines")"
     else
         jump "-->-->-->" "$(tail -1 <<< "${lines}")"
     fi
@@ -145,9 +145,18 @@ function jump {
 }
 
 function pmark {
-    local selected=$(echo "${1}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
-    local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
-    eval -- "$paste_command \"\$selected\""
+    local selected
+    if [[ $1 == "-->-->-->" ]]; then
+        selected=$2
+    else
+        local _fzm_keymap_description="ctrl-y:paste"
+        selected=$(_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
+    fi
+    if [[ $selected ]]; then
+        selected=$(sed 's/.*: \(.*\)$/\1/;s#^~#${HOME}#' <<< $selected)
+        local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
+        eval -- "$paste_command \"\$selected\""
+    fi
 }
 
 function dmark {


### PR DESCRIPTION
Hi, @urbainvaes @3ximus! I was playing with the latest version. This is a further improvement for #41 and #43. I think I managed to support working key bindings for Bash 3. This PR also includes miscellaneous other fixes. These fixes are not independent of one another, so I gave up to separate the PR into smaller ones. Here are the descriptions for each fix:

<details><summary>[ <b>Outdated</b>: I have rebased the commits. See <a href="#user-content-current-patch-set">current patch set</a>. ]</summary>

- Commit 4deba7c
  - It turned out that Bash 3 and 4 don't work with two-byte intermediate keys such as `mark1='\302\200'` which is used when the character encoding of the current locale is UTF-8. For UTF-8, I switched to use the bytes that will never be used in UTF-8, such as `\xC0`, `\xC1`, `\xF5`-`\xFF`. In addition, it seems that Bash 4 will unexpectedly terminate when it receives `\xFE` or `\xFF`, so finally, I decided to use `\xC0`, `\xC1` and `\xFD`.
  - For use in the later commits, I made the variables `mark{1..3}` global after renaming them to `_fzm_key{1..3}`.
- Commit 9f771d2
  - I added a support for Bash 3 so that the original contents and the cursor position of the command line is preserved after the invocation of `fzm`. It uses the same technique as `fzf` uses for Bash 3, which assumes that the key bindings to <kbd>C-u</kbd>, <kbd>C-e</kbd>, <kbd>C-k</kbd>, <kbd>C-y</kbd>, <kbd>M-y</kbd>, <kbd>M-space</kbd>, <kbd>C-x C-x</kbd>, and <kbd>C-m</kbd> are the Bash default.
  - For Bash 4, I added a workaround for the bashbug of `READLINE_POINT` (c.f. [bug-bash Mailing list - 2018-04/40](https://lists.gnu.org/archive/html/bug-bash/2018-04/msg00040.html)).
  - For Bash 5+, I added support for the variable `READLINE_MARK`, the new feature of Bash 5.0.
  - For Bash 4+ and `ble.sh` bindings, it is changed to go to the next line only when the current working directory is changed.
- Commit c0f299b
  - Now, the paste key (`ctrl-k` by default) is only enabled when `fzm` is used from key bindings, i.e., the paste key is disabled when `fzm` is executed from the command line.
  - The description of the key configuration displayed in the header of `fzf` is now properly set depending on the context (such as `fzf`, `jump`, `dmark`, or key bindings).
- Commit d747154
  -  `FZF_MARKS_JUMP` is now used also for the `ble.sh` binding. To support this, I updated `ble.sh` with the commit https://github.com/akinomyoga/ble.sh/commit/0f01cab8dce267fe75fa92c082c28b0d05c3d885 so that `ble-bind` accepts the Readline format (i.e., `bind` format) of key sequences with the type specifier `keyseq:`. Thus, this needs to be used with the latest devel version (`master` branch) of `ble.sh`.
- Commit 9f27330
  - Use `bind -x` for `FZF_MARKS_DMARK`
 </details>

Sorry for the relatively large set of changes. You can specify which changes from the above should be picked and which changes should be rejected so that I can adjust the related commits. Also, any comments, suggestions and questions are welcome!

Thank you

----

## Current Patch Set (Update 2021-01-03 04:54:31 JST)<a id="current-patch-set">†</a>

- Commit 4deba7c
  - It turned out that Bash 3 and 4 don't work with two-byte intermediate keys such as `mark1='\302\200'` which is used when the character encoding of the current locale is UTF-8. For UTF-8, I switched to use the bytes that will never be used in UTF-8, such as `\xC0`, `\xC1`, `\xF5`-`\xFF`. In addition, it seems that Bash 4 will unexpectedly terminate when it receives `\xFE` or `\xFF`, so finally, I decided to use `\xC0`, `\xC1` and `\xFD`.
  - For use in the later commits, I made the variables `mark{1..3}` global after renaming them to `_fzm_key{1..3}`.
- Commit 1d88f86
  - I added a support for Bash 3 so that the original contents and the cursor position of the command line is preserved after the invocation of `fzm`. It uses the same technique as `fzf` uses for Bash 3, which assumes that the key bindings to <kbd>C-u</kbd>, <kbd>C-e</kbd>, <kbd>C-k</kbd>, <kbd>C-y</kbd>, <kbd>M-y</kbd>, <kbd>M-space</kbd>, <kbd>C-x C-x</kbd>, <kbd>C-q</kbd>, <kbd>C-?</kbd>, <kbd>C-d</kbd>, and <kbd>C-m</kbd> are the Bash default.
  - For Bash 4, I added a workaround for the bashbug of `READLINE_POINT` (c.f. [bug-bash Mailing list - 2018-04/40](https://lists.gnu.org/archive/html/bug-bash/2018-04/msg00040.html)).
  - For Bash 5+, I added support for the variable `READLINE_MARK`, the new feature of Bash 5.0.
  - For Bash 4+ and `ble.sh` bindings, it is changed to go to the next line only when the current working directory is changed.
  - Now, `fzm` prints the selected path for `ctrl-k` by default when used outside the key bindings.
  - The command to be used for the "paste" operation outside the key bindings can be now configured with the variable `FZF_MARKS_PASTE_COMMAND`. When the variable is empty, `printf '%s\n'` will be used.
- Commit 0405ea1
  -  `FZF_MARKS_JUMP` is now used also for the `ble.sh` binding. To support this, I updated `ble.sh` with the commit https://github.com/akinomyoga/ble.sh/commit/0f01cab8dce267fe75fa92c082c28b0d05c3d885 so that `ble-bind` accepts the Readline format (i.e., `bind` format) of key sequences with the type specifier `keyseq:`. Thus, this needs to be used with the latest devel version (`master` branch) of `ble.sh`.
- Commit 873d7ba
  - Use `bind -x` for `FZF_MARKS_DMARK`
- Commit e844e30
  - Fix the vulnerability against code injection. For example, `jump '$(echo hello)'` causes an execution of `$(echo hello)` before the startup of `fzf`. For another example, `jump ' | echo hello '` would cause strange behavior.
- Commit 07d498e
  - I've escalated `pmark` as an independent command (just like `jump` and `dmark`) to print/paste the selected directory.
- Commit d15e285
  - The description of the key configuration displayed in the header of `fzf` is now properly set depending on the context (such as `fzf`, `jump`, `dmark`, or key bindings).
- Commit 6abe218
  - I changed `pmark` to output to stdout by default when the stdout is not TTY.
- Commit 95aa426
  - The default paste key `ctrl-k` has been changed to `ctrl-v`.
