### PR TITLE
Fix errors caused by "set -u"

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -22,15 +22,15 @@
 
 command -v fzf >/dev/null 2>&1 || return
 
-if [[ -z "${FZF_MARKS_FILE}" ]] ; then
-    FZF_MARKS_FILE="${HOME}/.fzf-marks"
+if [[ -z ${FZF_MARKS_FILE-} ]] ; then
+    FZF_MARKS_FILE=${HOME}/.fzf-marks
 fi
 
-if [[ ! -f "${FZF_MARKS_FILE}" ]]; then
+if [[ ! -f ${FZF_MARKS_FILE} ]]; then
     touch "${FZF_MARKS_FILE}"
 fi
 
-if [[ -z "${FZF_MARKS_COMMAND}" ]] ; then
+if [[ -z ${FZF_MARKS_COMMAND-} ]] ; then
 
     _fzm_FZF_VERSION=$(fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
     _fzm_MINIMUM_VERSION=16001
@@ -77,7 +77,7 @@ function _fzm_handle_symlinks {
 }
 
 function _fzm_color_marks {
-    if [[ "${FZF_MARKS_NO_COLORS}" == "1" ]]; then
+    if [[ "${FZF_MARKS_NO_COLORS-}" == "1" ]]; then
         cat
     else
         local esc c_lhs c_rhs c_colon
@@ -313,7 +313,7 @@ function ble/widget/fzm {
 
 function _fzm_setup_bindings {
     local jump_key=${FZF_MARKS_JUMP:-'\C-g'}
-    if ((_ble_version>=400)); then
+    if ((${_ble_version:-0} >= 400)); then
         ble-bind -f keyseq:"$jump_key" 'fzm'
     else
         # Intiialize special keys used for key bindings
@@ -336,7 +336,7 @@ function _fzm_setup_bindings {
         bind "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
     fi
 
-    if [ "${FZF_MARKS_DMARK}" ]; then
+    if [[ ${FZF_MARKS_DMARK-} ]]; then
         bind -x "\"${FZF_MARKS_DMARK}\": dmark"
     fi
 }

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -20,7 +20,7 @@
 
 command -v fzf >/dev/null 2>&1 || return
 
-if [[ -z "${FZF_MARKS_FILE}" ]] ; then
+if [[ -z "${FZF_MARKS_FILE-}" ]] ; then
     FZF_MARKS_FILE="${HOME}/.fzf-marks"
 fi
 
@@ -28,7 +28,7 @@ if [[ ! -f "${FZF_MARKS_FILE}" ]]; then
     touch "${FZF_MARKS_FILE}"
 fi
 
-if [[ -z "${FZF_MARKS_COMMAND}" ]] ; then
+if [[ -z "${FZF_MARKS_COMMAND-}" ]] ; then
 
     _fzm_FZF_VERSION=$(fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
     _fzm_MINIMUM_VERSION=16001
@@ -80,7 +80,7 @@ function redraw-prompt {
 zle -N redraw-prompt
 
 function _fzm_color_marks {
-    if [[ "${FZF_MARKS_NO_COLORS}" == "1" ]]; then
+    if [[ "${FZF_MARKS_NO_COLORS-}" == "1" ]]; then
         cat
     else
         local esc c_lhs c_rhs c_colon
@@ -188,7 +188,7 @@ zle -N dmark
 zle -N fzm
 
 bindkey ${FZF_MARKS_JUMP:-'^g'} fzm
-if [ "${FZF_MARKS_DMARK}" ]; then
+if [ "${FZF_MARKS_DMARK-}" ]; then
     bindkey ${FZF_MARKS_DMARK} dmark
 fi
 


### PR DESCRIPTION
When a user sets `set -u` (or, equivalently, `set -o nounset`) in `.bashrc`/`.zshrc` in prior to loading `fzf-marks`, error messages are output in Bash, or `fzf-marks` is not properly loaded in Zsh. This PR fixes the problem.
