### PR TITLE
Fix problems caused by echo when the messages resembles some options or when "shopt -s xpg_echo" is set

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -55,7 +55,7 @@ function mark {
     if grep -qxFe "${mark_to_add}" "${FZF_MARKS_FILE}"; then
         echo "** The following mark already exists **"
     else
-        echo "${mark_to_add}" >> "${FZF_MARKS_FILE}"
+        printf '%s\n' "${mark_to_add}" >> "${FZF_MARKS_FILE}"
         echo "** The following mark has been added **"
     fi
     _fzm_color_marks <<< $mark_to_add
@@ -73,7 +73,7 @@ function _fzm_handle_symlinks {
     else
         fname=${FZF_MARKS_FILE}
     fi
-    echo "${fname}"
+    printf '%s\n' "${fname}"
 }
 
 function _fzm_color_marks {
@@ -129,7 +129,7 @@ function jump {
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then
             perl -n -i -e "print unless /^\\Q${jumpline//\//\\/}\\E\$/" "${bookmarks}"
-            echo "${jumpline}" >> "${FZF_MARKS_FILE}"
+            printf '%s\n' "${jumpline}" >> "${FZF_MARKS_FILE}"
         fi
     fi
 }

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -58,7 +58,7 @@ function mark {
         echo "${mark_to_add}" >> "${FZF_MARKS_FILE}"
         echo "** The following mark has been added **"
     fi
-    echo "${mark_to_add}" | _fzm_color_marks
+    _fzm_color_marks <<< $mark_to_add
     _fzm_setup_completion
 }
 
@@ -124,7 +124,7 @@ function jump {
         jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
+        jumpdir=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< $jumpline)
         bookmarks=$(_fzm_handle_symlinks)
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then
@@ -143,7 +143,7 @@ function pmark {
         selected=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ $selected ]]; then
-        selected=$(sed 's/.*: \(.*\)$/\1/;s#^~#${HOME}#' <<< $selected)
+        selected=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< $selected)
         local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
         eval -- "$paste_command \"\$selected\""
     fi
@@ -167,7 +167,7 @@ function dmark {
         [[ $(wc -l <<< "${marks_to_delete}") == 1 ]] \
             && echo "** The following mark has been deleted **" \
             || echo "** The following marks have been deleted **"
-        echo "${marks_to_delete}" | _fzm_color_marks
+        _fzm_color_marks <<< $marks_to_delete
     fi
     _fzm_setup_completion
 }

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -52,7 +52,7 @@ function mark {
         echo "${mark_to_add}" >> "${FZF_MARKS_FILE}"
         echo "** The following mark has been added **"
     fi
-    echo "${mark_to_add}" | _fzm_color_marks
+    _fzm_color_marks <<< "${mark_to_add}"
 }
 
 function _fzm_handle_symlinks {
@@ -135,7 +135,7 @@ function jump {
         jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ -n ${jumpline} ]]; then
-        jumpdir=$(echo "${jumpline}" | sed 's/.*: \(.*\)$/\1/' | sed "s#^~#${HOME}#")
+        jumpdir=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< "$jumpline")
         bookmarks=$(_fzm_handle_symlinks)
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then
@@ -155,7 +155,7 @@ function pmark {
         selected=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} --ansi --bind=ctrl-y:accept --query='"$*"' --select-1 --tac)
     fi
     if [[ $selected ]]; then
-        selected=$(sed 's/.*: \(.*\)$/\1/;s#^~#${HOME}#' <<< $selected)
+        selected=$(sed 's/.*: \(.*\)$/\1/;'"s#^~#${HOME}#" <<< "$selected")
         local paste_command=${FZF_MARKS_PASTE_COMMAND:-"printf '%s\n'"}
         eval -- "$paste_command \"\$selected\""
     fi
@@ -179,7 +179,7 @@ function dmark {
         [[ $(wc -l <<< "${marks_to_delete}") == 1 ]] \
             && echo "** The following mark has been deleted **" \
             || echo "** The following marks have been deleted **"
-        echo "${marks_to_delete}" | _fzm_color_marks
+        _fzm_color_marks <<< "${marks_to_delete}"
     fi
     zle && zle reset-prompt
 }

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -49,7 +49,7 @@ function mark {
     if grep -qxFe "${mark_to_add}" "${FZF_MARKS_FILE}"; then
         echo "** The following mark already exists **"
     else
-        echo "${mark_to_add}" >> "${FZF_MARKS_FILE}"
+        printf '%s\n' "${mark_to_add}" >> "${FZF_MARKS_FILE}"
         echo "** The following mark has been added **"
     fi
     _fzm_color_marks <<< "${mark_to_add}"
@@ -66,7 +66,7 @@ function _fzm_handle_symlinks {
     else
         fname=${FZF_MARKS_FILE}
     fi
-    echo "${fname}"
+    printf '%s\n' "${fname}"
 }
 
 # Ensure precmds are run after cd
@@ -140,7 +140,7 @@ function jump {
         cd "${jumpdir}" || return
         if ! [[ "${FZF_MARKS_KEEP_ORDER}" == 1 ]]; then
             perl -n -i -e "print unless /^\\Q${jumpline//\//\\/}\\E\$/" "${bookmarks}"
-            echo "${jumpline}" >> "${FZF_MARKS_FILE}"
+            printf '%s\n' "${jumpline}" >> "${FZF_MARKS_FILE}"
         fi
     fi
     zle && zle redraw-prompt


### PR DESCRIPTION
In general, we need to carefully use the builtin `echo` when the message can contain arbitrary strings.

- The `echo` builtin accepts options such as `-n`, `-e`, or `--` (actually the set of supported options differs between shells), which means that when the message text is confusing with these options, `echo` behaves in a unexpected way.
- When a user sets `shopt -s xpg_echo` in `.bashrc` or `set -o BSD_ECHO` in `.zshrc`, the builtin `echo` processes backslashes in the message as an escape sequence, which would also cause unexpected behavior when the mark name, `FZF_MARKS_FILE`, or the directory paths contain backslashes.

So, when the message can contain arbitrary strings, we can use the `printf '%s\n' ...` idiom instead. Here is the fix.