### PR TITLE
Add support for XDG Base Directory spec

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -22,12 +22,25 @@
 
 command -v fzf >/dev/null 2>&1 || return
 
+PROGRAM_NAME="${PROGRAM_NAME:-fzf-marks}"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/$PROGRAM_NAME" #currently unused, but in the future can be used to load (and store?) an .env file from to more easily switch between multiple configuration
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/$PROGRAM_NAME"
+LEGACY_FZF_MARKS_FILE="${HOME}/.fzf-marks"
+
 if [[ -z ${FZF_MARKS_FILE-} ]] ; then
-    FZF_MARKS_FILE=${HOME}/.fzf-marks
+    FZF_MARKS_FILE="${DATA_DIR}/default_bookmarks.fzf-marks"
 fi
 
-if [[ ! -f ${FZF_MARKS_FILE} ]]; then
+if [[ ! -f "${FZF_MARKS_FILE}" ]]; then
+  # Fallback support for the previous default location of the bookmarks file.
+  if [[ -f "$LEGACY_FZF_MARKS_FILE" ]]; then
+    echo "Your FZF_MARKS_FILE is still in its legacy location of $LEGACY_FZF_MARKS_FILE; you might want to consider moving it to "$FZF_MARKS_FILE" so it follows the XDG standard, or explicitly set FZF_MARKS_FILE='$LEGACY_FZF_MARKS_FILE'." >&2
+    FZF_MARKS_FILE="$LEGACY_FZF_MARKS_FILE"
+  else
+    [[ ! -d "$DATA_DIR" ]] && mkdir "$DATA_DIR" && chmod 700 "$DATA_DIR"
     touch "${FZF_MARKS_FILE}"
+  fi
 fi
 
 if [[ -z ${FZF_MARKS_COMMAND-} ]] ; then


### PR DESCRIPTION
With the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/) becoming more widely accepted, it would be nice if fzf-marks could also support this.

This change defaults the FZF_MARKS_FILE location to $XDG_DATA_HOME/fzf-marks, which usually would be ~/.local/share/fzf-marks.

A special case is still made however for the previous location of ~/.fzf-marks, so upgrading users won't suddenly find their marks empty. If no marks file is found in the new location, and one is found in the legacy location, then a warning is raised via STDERR, and FZF_MARKS_FILE is set to the legacy location. This will be done only once every time the script is sourced till the file is either moved, or FZF_MARKS_FILE is explictly set.

I've only implemented this in Bash, as I'm not familiar with zsh myself, but it should probably be trivial to port over these changes to the zsh script too if this change is desirable.

While no support for config file(s) has been added yet (I do have some ideas for this), a CONFIG_DIR var has already been added too, so those also can be added in a location that follows the XDG Base Directories spec.

My changes follow examples as posted on https://www.ctrl.blog/entry/xdg-basedir-scripting.html