### PR TITLE
[feat] add comment syntax for .fzf-marks file

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -78,14 +78,14 @@ function _fzm_handle_symlinks {
 
 function _fzm_color_marks {
     if [[ "${FZF_MARKS_NO_COLORS-}" == "1" ]]; then
-        cat
+        grep "^[^#]" | cat
     else
         local esc c_lhs c_rhs c_colon
         esc=$(printf '\033')
         c_lhs=${FZF_MARKS_COLOR_LHS:-39}
         c_rhs=${FZF_MARKS_COLOR_RHS:-36}
         c_colon=${FZF_MARKS_COLOR_COLON:-33}
-        sed "s/^\\(.*\\) : \\(.*\\)$/${esc}[${c_lhs}m\\1${esc}[0m ${esc}[${c_colon}m:${esc}[0m ${esc}[${c_rhs}m\\2${esc}[0m/"
+        grep "^[^#]" | sed "s/^\\(.*\\) : \\(.*\\)$/${esc}[${c_lhs}m\\1${esc}[0m ${esc}[${c_colon}m:${esc}[0m ${esc}[${c_rhs}m\\2${esc}[0m/"
     fi
 }
 

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -81,14 +81,14 @@ zle -N redraw-prompt
 
 function _fzm_color_marks {
     if [[ "${FZF_MARKS_NO_COLORS-}" == "1" ]]; then
-        cat
+        grep "^[^#]" | cat
     else
         local esc c_lhs c_rhs c_colon
         esc=$(printf '\033')
         c_lhs=${FZF_MARKS_COLOR_LHS:-39}
         c_rhs=${FZF_MARKS_COLOR_RHS:-36}
         c_colon=${FZF_MARKS_COLOR_COLON:-33}
-        sed "s/^\\(.*\\) : \\(.*\\)$/${esc}[${c_lhs}m\\1${esc}[0m ${esc}[${c_colon}m:${esc}[0m ${esc}[${c_rhs}m\\2${esc}[0m/"
+        grep "^[^#]" | sed "s/^\\(.*\\) : \\(.*\\)$/${esc}[${c_lhs}m\\1${esc}[0m ${esc}[${c_colon}m:${esc}[0m ${esc}[${c_rhs}m\\2${esc}[0m/"
     fi
 }
 


### PR DESCRIPTION
Sometimes we want to group different bookmarks. At this time, we can use the syntax of comments. At present, I use the symbol `#` as the prefix of the comment.

![fzf-marks-comments](https://user-images.githubusercontent.com/35610874/140650427-53c857b6-41f2-4c59-89a5-d8d4893aaf9a.png)


