### PR TITLE
auto-accept on exact match

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -120,6 +120,11 @@ function jump {
     if [[ $1 == "-->-->-->" ]]; then
         jumpline=$2
     else
+        # accept if provided string matches a single bookmark exactly
+        (($#)) && jumpline=$(grep "^$* : .*\$" "$FZF_MARKS_FILE")
+        [[ ${jumpline} =~ $'\n' ]] && jumpline=
+        # if not, prompt using fzf
+        [[ $jumpline ]] || \
         jumpline=$(_fzm_color_marks < "${FZF_MARKS_FILE}" | eval ${FZF_MARKS_COMMAND} \
             --ansi \
             --bind=ctrl-y:accept \


### PR DESCRIPTION
e.g. if I have only one bookmark containing the string `foo` exactly and I type `jump foo`, don't bother bringing up fzf and just cd to that directory. This differs from the current behavior in that if I have a bookmark that is an inexact match for `foo` (like `four`) then fzf will not currently auto-accept the exact match.

Repaired and rebased from https://github.com/urbainvaes/fzf-marks/pull/38