### PR TITLE
Disable sort so that matches are sorted most-recent first

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -99,6 +99,7 @@ function fzm {
         --header='"ctrl-y:jump, ctrl-t:toggle, $delete_key:delete, $paste_key:paste"' \
         --query='"$*"' \
         --select-1 \
+        --no-sort \
         --tac)
     if [[ -z "$lines" ]]; then
         return 1
@@ -126,6 +127,7 @@ function jump {
             --header='"ctrl-y:jump"' \
             --query='"$*"' \
             --select-1 \
+            --no-sort \
             --tac)
     fi
     if [[ -n ${jumpline} ]]; then


### PR DESCRIPTION
Maybe there should be an environment variable to control this behavior, but I've found I prefer it much better than sorted.