### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ It depends on Junegunn Choi's fuzzy-finder [fzf](https://github.com/junegunn/fzf
 
 # Installation
 
+### Fig
+
+You can use [Fig](https://fig.io) to install `fzf-marks` on zsh, fish, or bash with just one click.
+
+<a href="https://fig.io/plugins/other/powerlevel10k" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Zsh
 
 If you use *zsh*, I recommend installing with a plugin manager.


### PR DESCRIPTION
We recently listed `fzf-marks` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. I put it at the top of installation options because it's a shell-agnostic install method, but feel free to change that if you need to. Thanks so much and please let me know if you have any questions!