### PR TITLE
Make sure script doesn't execute if `fzf` is an alias and the command doesn't actually exist

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -32,15 +32,15 @@ fi
 
 if [[ -z ${FZF_MARKS_COMMAND-} ]] ; then
 
-    _fzm_FZF_VERSION=$(fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
+    _fzm_FZF_VERSION=$(command fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
     _fzm_MINIMUM_VERSION=16001
 
     if [[ $_fzm_FZF_VERSION -gt $_fzm_MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse"
+        FZF_MARKS_COMMAND="command fzf --height 40% --reverse"
     elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
-        FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
+        FZF_MARKS_COMMAND="command fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
     else
-        FZF_MARKS_COMMAND="fzf"
+        FZF_MARKS_COMMAND="command fzf"
     fi
 fi
 

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-command -v fzf >/dev/null 2>&1 || return
+type -P fzf >/dev/null || return
 
 if [[ -z ${FZF_MARKS_FILE-} ]] ; then
     FZF_MARKS_FILE=$HOME/.fzf-marks

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -30,15 +30,15 @@ fi
 
 if [[ -z ${FZF_MARKS_COMMAND-} ]] ; then
 
-    _fzm_FZF_VERSION=$(fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
+    _fzm_FZF_VERSION=$(command fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
     _fzm_MINIMUM_VERSION=16001
 
     if [[ $_fzm_FZF_VERSION -gt $_fzm_MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse"
+        FZF_MARKS_COMMAND="command fzf --height 40% --reverse"
     elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
-        FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
+        FZF_MARKS_COMMAND="command fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
     else
-        FZF_MARKS_COMMAND="fzf"
+        FZF_MARKS_COMMAND="command fzf"
     fi
 fi
 

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-type -P fzf >/dev/null || return
+type -p fzf >/dev/null || return
 
 if [[ -z ${FZF_MARKS_FILE-} ]] ; then
     FZF_MARKS_FILE=$HOME/.fzf-marks

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-command -v fzf >/dev/null 2>&1 || return
+type -P fzf >/dev/null || return
 
 if [[ -z ${FZF_MARKS_FILE-} ]] ; then
     FZF_MARKS_FILE=$HOME/.fzf-marks


### PR DESCRIPTION
This is a very simple fix for the case where you have an alias for fzf but the fzf command doesn't actually exist