### PR TITLE
fix conditional statement logic for fzf command

### DIFF
--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -33,10 +33,10 @@ if [[ -z ${FZF_MARKS_COMMAND-} ]] ; then
     _fzm_FZF_VERSION=$(fzf --version | awk -F. '{ print $1 * 1e6 + $2 * 1e3 + $3 }')
     _fzm_MINIMUM_VERSION=16001
 
-    if [[ $_fzm_FZF_VERSION -gt $_fzm_MINIMUM_VERSION ]]; then
-        FZF_MARKS_COMMAND="fzf --height 40% --reverse"
-    elif [[ ${FZF_TMUX:-1} -eq 1 ]]; then
+    if (( $+commands[fzf-tmux] )); then
         FZF_MARKS_COMMAND="fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}"
+    elif [[ $_fzm_FZF_VERSION -gt $_fzm_MINIMUM_VERSION ]]; then
+        FZF_MARKS_COMMAND="fzf --height 40% --reverse"
     else
         FZF_MARKS_COMMAND="fzf"
     fi


### PR DESCRIPTION
Without this `[[ ${FZF_TMUX:-1} -eq 1 ]]` would only be evaluated fzf if `_fzm_FZF_VERSION` was under `$_fzm_MINIMUM_VERSION`