### PR TITLE
Add vi mode support

### DIFF
--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -342,7 +342,7 @@ function _fzm_setup_bindings {
         fi
 
         bind -x "\"$_fzm_key1\": _fzm-widget"
-        bind "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
+        bind -m emacs "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
         bind -m vi-command "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
         bind -m vi-insert "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
     fi

--- a/fzf-marks.plugin.bash
+++ b/fzf-marks.plugin.bash
@@ -343,6 +343,8 @@ function _fzm_setup_bindings {
 
         bind -x "\"$_fzm_key1\": _fzm-widget"
         bind "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
+        bind -m vi-command "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
+        bind -m vi-insert "\"$jump_key\":\"$_fzm_key1$_fzm_key2\""
     fi
 
     if [[ ${FZF_MARKS_DMARK-} ]]; then

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -197,6 +197,8 @@ zle -N dmark
 zle -N fzm
 
 bindkey ${FZF_MARKS_JUMP:-'^g'} fzm
+bindkey -M vicmd ${FZF_MARKS_JUMP:-'^g'} fzm
+bindkey -M viins ${FZF_MARKS_JUMP:-'^g'} fzm
 if [ "${FZF_MARKS_DMARK-}" ]; then
     bindkey ${FZF_MARKS_DMARK} dmark
 fi

--- a/fzf-marks.plugin.zsh
+++ b/fzf-marks.plugin.zsh
@@ -196,7 +196,7 @@ function dmark {
 zle -N dmark
 zle -N fzm
 
-bindkey ${FZF_MARKS_JUMP:-'^g'} fzm
+bindkey -M emacs ${FZF_MARKS_JUMP:-'^g'} fzm
 bindkey -M vicmd ${FZF_MARKS_JUMP:-'^g'} fzm
 bindkey -M viins ${FZF_MARKS_JUMP:-'^g'} fzm
 if [ "${FZF_MARKS_DMARK-}" ]; then


### PR DESCRIPTION
This MR adds support for vi mode. In short, it ensures `^g` is bound even if in `insert` or `command` mode.

----

Resolves #70 